### PR TITLE
feat: AutoNazar hot-reload support + thread-safe key activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,52 @@
 ![Nuget version](https://img.shields.io/nuget/v/MyJetWallet.Fireblocks.Client?label=MyJetWallet.Fireblocks.Client&style=social)
 
+## Hot-reload key activation (AutoNazar integration)
+
+Services that use `RegisterEmbeddedFireblocksClientFromStorage` can rotate Fireblocks credentials at runtime
+without a pod restart by subscribing to AutoNazar key push notifications.
+
+### How it works
+
+`RegisterEmbeddedFireblocksClientFromStorage` now registers `EmbeddedKeyActivators` in the DI container.
+This object holds two `KeyActivator` instances — one for Admin credentials, one for Signer credentials.
+
+When AutoNazar pushes a new key via `INotificatorSubscriber`, the service calls `ActivateKeys()` on the
+matching activator. `JwtTokenGenerator` immediately swaps to the new RSA key (atomic swap — no request
+is dropped during rotation).
+
+### Service-side setup (ApplicationLifetimeManager)
+
+```csharp
+// Inject in constructor:
+private readonly EmbeddedKeyActivators _keyActivators;
+private readonly INotificatorSubscriber _notificatorSubscriber;
+
+// Subscribe in OnStarted():
+_notificatorSubscriber.Subscribe(key =>
+{
+    if (key.Id == Program.Settings.FireblocksAdminKeyId)
+        _keyActivators.Admin.ActivateKeys(key.ApiKeyValue, key.PrivateKeyValue);
+
+    if (key.Id == Program.Settings.FireblocksSignerKeyId)
+        _keyActivators.Signer.ActivateKeys(key.ApiKeyValue, key.PrivateKeyValue);
+});
+```
+
+### Settings required
+
+```
+FireblocksAdminKeyId  — AutoNazar key ID for admin credentials  (e.g. "embedded-fireblocks-admin-key")
+FireblocksSignerKeyId — AutoNazar key ID for signer credentials (e.g. "embedded-fireblocks-signer-key")
+```
+
+### Fallback behaviour
+
+If AutoNazar is unavailable at startup, credentials from environment variables (`FallbackAdminApiKey`,
+`FallbackAdminPrivateKey`, etc. in `EmbeddedFireblocksStorageOptions`) are used as initial values.
+The Notificator subscription will activate hot-reload as soon as AutoNazar becomes available.
+
+---
+
 Generate Fireblocks API Client flow
 
 1. Update api-spec-2.yaml

--- a/src/MyJetWallet.Fireblocks.Client/ApiClients.cs
+++ b/src/MyJetWallet.Fireblocks.Client/ApiClients.cs
@@ -36600,7 +36600,7 @@ namespace MyJetWallet.Fireblocks.Client
         /// </summary>
         [Newtonsoft.Json.JsonProperty("type", Required = Newtonsoft.Json.Required.Always)]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+        [Newtonsoft.Json.JsonConverter(typeof(MyJetWallet.Fireblocks.Client.FallbackStringEnumConverter))]
         public AssetTypeResponseType Type { get; set; }
 
         /// <summary>
@@ -50090,6 +50090,12 @@ namespace MyJetWallet.Fireblocks.Client
 
         [System.Runtime.Serialization.EnumMember(Value = @"SUI_ASSET")]
         SUI_ASSET = 17,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"PROVENANCE_MARKER_TOKEN")]
+        PROVENANCE_MARKER_TOKEN = 18,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"UNKNOWN")]
+        UNKNOWN = 999,
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.2.0.0 (NJsonSchema v11.1.0.0 (Newtonsoft.Json v13.0.0.0))")]

--- a/src/MyJetWallet.Fireblocks.Client/Auth/JwtTokenGenerator.cs
+++ b/src/MyJetWallet.Fireblocks.Client/Auth/JwtTokenGenerator.cs
@@ -106,7 +106,7 @@ namespace MyJetWallet.Fireblocks.Client.Auth
 
         public void Dispose()
         {
-            _rsa.Dispose();
+            _rsa?.Dispose();
             _keyActivator.KeyActivatedEvent -= Activate;
         }
     }

--- a/src/MyJetWallet.Fireblocks.Client/Auth/JwtTokenGenerator.cs
+++ b/src/MyJetWallet.Fireblocks.Client/Auth/JwtTokenGenerator.cs
@@ -3,6 +3,7 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Net.Http;
 using System.Security.Cryptography;
 using System.Text;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.IdentityModel.Tokens;
 using Newtonsoft.Json;
@@ -13,7 +14,7 @@ namespace MyJetWallet.Fireblocks.Client.Auth
     {
         private readonly ClientConfigurator _fireblocksConfiguration;
         private readonly KeyActivator _keyActivator;
-        private SigningCredentials _signingCredentials;
+        private volatile SigningCredentials _signingCredentials;
         private RSA _rsa;
 
         public JwtTokenGenerator(ClientConfigurator configuration, KeyActivator keyActivator)
@@ -58,17 +59,24 @@ namespace MyJetWallet.Fireblocks.Client.Auth
         {
             try
             {
+                if (_signingCredentials != null
+                    && _fireblocksConfiguration.ApiKey == apiKey
+                    && _fireblocksConfiguration.ApiPrivateKey == privateKey)
+                    return;
+
                 _fireblocksConfiguration.ApiKey = apiKey;
                 _fireblocksConfiguration.ApiPrivateKey = privateKey;
 
                 var newRsa = RSA.Create();
-                newRsa.ImportPkcs8PrivateKey(Convert.FromBase64String(_fireblocksConfiguration.ApiPrivateKey), out _);
+                newRsa.ImportPkcs8PrivateKey(Convert.FromBase64String(privateKey), out _);
                 var newCredentials = new SigningCredentials(new RsaSecurityKey(newRsa), SecurityAlgorithms.RsaSha256);
 
                 var oldRsa = _rsa;
                 _rsa = newRsa;
                 _signingCredentials = newCredentials;
-                oldRsa?.Dispose();
+
+                if (oldRsa != null)
+                    Task.Run(async () => { await Task.Delay(30_000); oldRsa.Dispose(); });
             }
             catch (Exception e)
             {

--- a/src/MyJetWallet.Fireblocks.Client/Auth/JwtTokenGenerator.cs
+++ b/src/MyJetWallet.Fireblocks.Client/Auth/JwtTokenGenerator.cs
@@ -60,11 +60,15 @@ namespace MyJetWallet.Fireblocks.Client.Auth
             {
                 _fireblocksConfiguration.ApiKey = apiKey;
                 _fireblocksConfiguration.ApiPrivateKey = privateKey;
-                _rsa?.Dispose();
-                _rsa = RSA.Create();
-                _rsa.ImportPkcs8PrivateKey(Convert.FromBase64String(_fireblocksConfiguration.ApiPrivateKey), out _);
-                var securityKey = new RsaSecurityKey(_rsa);
-                _signingCredentials = new SigningCredentials(securityKey, SecurityAlgorithms.RsaSha256);
+
+                var newRsa = RSA.Create();
+                newRsa.ImportPkcs8PrivateKey(Convert.FromBase64String(_fireblocksConfiguration.ApiPrivateKey), out _);
+                var newCredentials = new SigningCredentials(new RsaSecurityKey(newRsa), SecurityAlgorithms.RsaSha256);
+
+                var oldRsa = _rsa;
+                _rsa = newRsa;
+                _signingCredentials = newCredentials;
+                oldRsa?.Dispose();
             }
             catch (Exception e)
             {

--- a/src/MyJetWallet.Fireblocks.Client/Auth/KeyActivator.cs
+++ b/src/MyJetWallet.Fireblocks.Client/Auth/KeyActivator.cs
@@ -9,6 +9,7 @@ namespace MyJetWallet.Fireblocks.Client.Auth
     public class KeyActivator
     {
         public bool IsActivated { get; set; } = false;
+        public DateTime StartedAt { get; } = DateTime.UtcNow;
         public KeyActivator()
         {
         }

--- a/src/MyJetWallet.Fireblocks.Client/Autofac/AutofacHelper.cs
+++ b/src/MyJetWallet.Fireblocks.Client/Autofac/AutofacHelper.cs
@@ -276,6 +276,35 @@ namespace MyJetWallet.Fireblocks.Client.Autofac
             builder.Register(ctx => ctx.Resolve<FireblocksEmbeddedClients>().WebhooksSigner).As<IWebhooksClientSigner>().SingleInstance();
             builder.Register(ctx => ctx.Resolve<FireblocksEmbeddedClients>().EmbeddedWalletAdmin).As<IEmbeddedWalletAdminClient>().SingleInstance();
             builder.Register(ctx => ctx.Resolve<FireblocksEmbeddedClients>().EmbeddedWalletSigner).As<IEmbeddedWalletSignerClient>().SingleInstance();
+            builder.Register(ctx => ctx.Resolve<FireblocksEmbeddedClients>().KeyActivators)
+                .As<EmbeddedKeyActivators>()
+                .SingleInstance();
+        }
+
+        public static HttpClient CreateHttpClient(
+            ClientConfigurator clientConfigurator,
+            KeyActivator keyActivator,
+            params DelegatingHandler[] handlers)
+        {
+            var baseUrl = clientConfigurator.BaseUrl;
+
+            if (string.IsNullOrEmpty(baseUrl))
+                throw new Exception("clientConfigurator.BaseUrl cannot be empty");
+
+            if (!baseUrl.Contains("/v1"))
+                throw new Exception("clientConfigurator.BaseUrl should be with /v1");
+
+            var auth = new ApiKeyHeaderGenerator(clientConfigurator, new JwtTokenGenerator(clientConfigurator, keyActivator), keyActivator);
+            var handlersWithAuth = new List<DelegatingHandler> { new NonceErrorHandler(), new AuthHandler(auth) };
+
+            keyActivator.ActivateKeys(clientConfigurator.ApiKey, clientConfigurator.ApiPrivateKey);
+
+            if (handlers != null && handlers.Any())
+            {
+                handlersWithAuth.AddRange(handlers);
+            }
+
+            return HttpClientFactory.Create(handlersWithAuth.ToArray());
         }
 
         public static HttpClient CreateHttpClient(ClientConfigurator clientConfigurator, params DelegatingHandler[] handlers)

--- a/src/MyJetWallet.Fireblocks.Client/Embedded/Models/ApiClientsModels.cs
+++ b/src/MyJetWallet.Fireblocks.Client/Embedded/Models/ApiClientsModels.cs
@@ -10,7 +10,7 @@ namespace MyJetWallet.Fireblocks.Client
     public partial class TransactionResponse
     {
         [Newtonsoft.Json.JsonProperty("assetType")]
-        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+        [Newtonsoft.Json.JsonConverter(typeof(MyJetWallet.Fireblocks.Client.FallbackStringEnumConverter))]
         public AssetTypeResponseType AssetType { get; set; }
 
         [Newtonsoft.Json.JsonProperty("replacedTxHash")]

--- a/src/MyJetWallet.Fireblocks.Client/EmbeddedKeyActivators.cs
+++ b/src/MyJetWallet.Fireblocks.Client/EmbeddedKeyActivators.cs
@@ -1,0 +1,16 @@
+using MyJetWallet.Fireblocks.Client.Auth;
+
+namespace MyJetWallet.Fireblocks.Client
+{
+    public class EmbeddedKeyActivators
+    {
+        public KeyActivator Admin { get; }
+        public KeyActivator Signer { get; }
+
+        public EmbeddedKeyActivators(KeyActivator admin, KeyActivator signer)
+        {
+            Admin = admin;
+            Signer = signer;
+        }
+    }
+}

--- a/src/MyJetWallet.Fireblocks.Client/FallbackStringEnumConverter.cs
+++ b/src/MyJetWallet.Fireblocks.Client/FallbackStringEnumConverter.cs
@@ -1,0 +1,36 @@
+#nullable enable
+
+namespace MyJetWallet.Fireblocks.Client
+{
+    /// <summary>
+    /// A JsonConverter that gracefully handles unknown enum values
+    /// by falling back to UNKNOWN instead of throwing an exception.
+    /// This prevents deserialization failures when Fireblocks adds new asset types.
+    /// </summary>
+    public class FallbackStringEnumConverter : Newtonsoft.Json.JsonConverter
+    {
+        private readonly Newtonsoft.Json.Converters.StringEnumConverter _inner = new();
+
+        public override bool CanConvert(System.Type objectType) => _inner.CanConvert(objectType);
+
+        public override void WriteJson(Newtonsoft.Json.JsonWriter writer, object? value, Newtonsoft.Json.JsonSerializer serializer)
+        {
+            _inner.WriteJson(writer, value, serializer);
+        }
+
+        public override object? ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object? existingValue, Newtonsoft.Json.JsonSerializer serializer)
+        {
+            try
+            {
+                return _inner.ReadJson(reader, objectType, existingValue, serializer);
+            }
+            catch (Newtonsoft.Json.JsonSerializationException)
+            {
+                var enumType = System.Nullable.GetUnderlyingType(objectType) ?? objectType;
+                if (System.Enum.TryParse(enumType, "UNKNOWN", out var unknownValue))
+                    return unknownValue;
+                return System.Enum.GetValues(enumType).GetValue(0);
+            }
+        }
+    }
+}

--- a/src/MyJetWallet.Fireblocks.Client/FireblocksEmbeddedClients.cs
+++ b/src/MyJetWallet.Fireblocks.Client/FireblocksEmbeddedClients.cs
@@ -1,3 +1,4 @@
+using MyJetWallet.Fireblocks.Client.Auth;
 using MyJetWallet.Fireblocks.Client.Autofac;
 using MyJetWallet.Fireblocks.Client.Embedded;
 
@@ -5,6 +6,8 @@ namespace MyJetWallet.Fireblocks.Client
 {
     public class FireblocksEmbeddedClients
     {
+        public EmbeddedKeyActivators KeyActivators { get; }
+
         public IVaultClientAdmin VaultAdmin { get; }
         public IVaultClientSigner VaultSigner { get; }
         public IAccountsClientAdmin AccountsAdmin { get; }
@@ -24,10 +27,14 @@ namespace MyJetWallet.Fireblocks.Client
 
         public FireblocksEmbeddedClients(ClientConfigurator adminConfig, ClientConfigurator signerConfig)
         {
+            var adminActivator  = new KeyActivator();
+            var signerActivator = new KeyActivator();
+            KeyActivators = new EmbeddedKeyActivators(adminActivator, signerActivator);
+
             var baseUrlAdmin  = adminConfig.BaseUrl;
             var baseUrlSigner = signerConfig.BaseUrl;
-            var httpAdmin  = AutofacHelper.CreateHttpClient(adminConfig);
-            var httpSigner = AutofacHelper.CreateHttpClient(signerConfig);
+            var httpAdmin  = AutofacHelper.CreateHttpClient(adminConfig, adminActivator);
+            var httpSigner = AutofacHelper.CreateHttpClient(signerConfig, signerActivator);
 
             VaultAdmin           = new VaultClient(adminConfig, httpAdmin)           { BaseUrl = baseUrlAdmin };
             VaultSigner          = new VaultClient(signerConfig, httpSigner)         { BaseUrl = baseUrlSigner };

--- a/src/MyJetWallet.Fireblocks.Client/MyJetWallet.Fireblocks.Client.csproj
+++ b/src/MyJetWallet.Fireblocks.Client/MyJetWallet.Fireblocks.Client.csproj
@@ -9,7 +9,7 @@
     <RepositoryUrl>https://github.com/MyJetWallet/MyJetWallet.Fireblocks.Client</RepositoryUrl>
     <PackageTags>Fireblocks MyJetWallet.Fireblocks.Client.Net C# .Net CryptoCurrency Wallet Exchange Rest API Wrapper</PackageTags>
     <NeutralLanguage>en</NeutralLanguage>
-    <Version>2.5.0</Version>
+    <Version>2.6.0</Version>
     <RootNamespace>MyJetWallet.Fireblocks.Client</RootNamespace>
   </PropertyGroup>
 

--- a/src/MyJetWallet.Fireblocks.Client/MyJetWallet.Fireblocks.Client.csproj
+++ b/src/MyJetWallet.Fireblocks.Client/MyJetWallet.Fireblocks.Client.csproj
@@ -9,7 +9,7 @@
     <RepositoryUrl>https://github.com/MyJetWallet/MyJetWallet.Fireblocks.Client</RepositoryUrl>
     <PackageTags>Fireblocks MyJetWallet.Fireblocks.Client.Net C# .Net CryptoCurrency Wallet Exchange Rest API Wrapper</PackageTags>
     <NeutralLanguage>en</NeutralLanguage>
-    <Version>2.6.0</Version>
+    <Version>2.7.0</Version>
     <RootNamespace>MyJetWallet.Fireblocks.Client</RootNamespace>
   </PropertyGroup>
 

--- a/src/MyJetWallet.Fireblocks.Client/MyJetWallet.Fireblocks.Client.csproj
+++ b/src/MyJetWallet.Fireblocks.Client/MyJetWallet.Fireblocks.Client.csproj
@@ -9,7 +9,7 @@
     <RepositoryUrl>https://github.com/MyJetWallet/MyJetWallet.Fireblocks.Client</RepositoryUrl>
     <PackageTags>Fireblocks MyJetWallet.Fireblocks.Client.Net C# .Net CryptoCurrency Wallet Exchange Rest API Wrapper</PackageTags>
     <NeutralLanguage>en</NeutralLanguage>
-    <Version>2.4.0</Version>
+    <Version>2.5.0</Version>
     <RootNamespace>MyJetWallet.Fireblocks.Client</RootNamespace>
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary
- Expose `EmbeddedKeyActivators` (Admin + Signer) from `RegisterEmbeddedFireblocksClientFromStorage` for AutoNazar hot-reload
- Thread-safe `JwtTokenGenerator.Activate()`: early return on unchanged key, volatile `_signingCredentials`, deferred RSA dispose (30s grace period)
- `KeyActivator.StartedAt` property for consumer-side readiness checks
- `FallbackStringEnumConverter` + `PROVENANCE_MARKER_TOKEN` enum for resilient deserialization
- Null-safe `Dispose()`

## Breaking changes
None. Old `CreateHttpClient` overload unchanged. `EmbeddedKeyActivators` is additive — services that don't inject it are unaffected.

## Version
2.7.0

## Test plan
- [ ] Build passes (0 errors)
- [ ] UAT: deploy Service.EmbeddedWallet with Notificator subscription → verify "Set Api Keys" logs every ~30s
- [ ] UAT: verify no `ObjectDisposedException: RSAOpenSsl` under hot-reload
- [ ] UAT: verify no `Status: 401` after key rotation
- [ ] Existing consumers without nuget update — no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)